### PR TITLE
Cut off range of blue color which is similar to unassigned point MATH…

### DIFF
--- a/src/services/users/utils.hooks.js
+++ b/src/services/users/utils.hooks.js
@@ -76,7 +76,7 @@ function getRandomColor() {
     return [
         Math.floor(Math.random() * 256),
         Math.floor(Math.random() * 256),
-        Math.floor(Math.random() * 256),
+        Math.floor(Math.random() * 160),
     ];
 }
 


### PR DESCRIPTION
…NETNG-146
1. After cut range of blue color to 160, all blue points will be darker than unassigned point color. Lighter than unassigned point color would be unreadable.